### PR TITLE
Changing noun finding to insignificant word stripping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
  * Create virtual environment `virtualenv hqtrivia-bot`
  * Start virtual environment `source hqtrivia-bot/bin/activate`
  * Install bot dependencies `pip install -r requirements.txt`
- * Install NLTK corpora `python -m nltk.downloader punkt; python -m nltk.downloader averaged_perceptron_tagger`
+ * Install NLTK corpora `python -m nltk.downloader stopwords`
 
 
 ### Get Bearer Token and User ID

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,5 @@
 import re
 import sys
-import nltk
 from nltk.corpus import stopwords
 import requests_cache
 import grequests
@@ -194,15 +193,6 @@ def find_keywords(keywords, data):
             if keyword in data and keyword not in words_found:
                 words_found.append(data.count(keyword))
     return words_found
-
-
-# Get nouns from text
-def get_text_nouns(input):
-    response = ''
-    for (word, tag) in nltk.pos_tag(nltk.word_tokenize(input)):
-        if tag.startswith('NN') or tag.startswith('NNP'):
-            response += word + ' '
-    return response.strip()
 
 
 # Returns a list of the words from the input string that are not in NLTK's stopwords


### PR DESCRIPTION
This PR uses a new function to get `question_nouns`, that removes 'stopwords' instead of leaving only 'nouns'.

These are examples(? this might be all of them) of the stopwords that are removed:

`['all', 'just', 'being', 'over', 'both', 'through', 'yourselves', 'its', 'before', 'herself', 'had', 'should', 'to', 'only', 'under', 'ours', 'has', 'do', 'them', 'his', 'very', 'they', 'not', 'during', 'now', 'him', 'nor', 'did', 'this', 'she', 'each', 'further', 'where', 'few', 'because', 'doing', 'some', 'are', 'our', 'ourselves', 'out', 'what', 'for', 'while', 'does', 'above', 'between', 't', 'be', 'we', 'who', 'were', 'here', 'hers', 'by', 'on', 'about', 'of', 'against', 's', 'or', 'own', 'into', 'yourself', 'down', 'your', 'from', 'her', 'their', 'there', 'been', 'whom', 'too', 'themselves', 'was', 'until', 'more', 'himself', 'that', 'but', 'don', 'with', 'than', 'those', 'he', 'me', 'myself', 'these', 'up', 'will', 'below', 'can', 'theirs', 'my', 'and', 'then', 'is', 'am', 'it', 'an', 'as', 'itself', 'at', 'have', 'in', 'any', 'if', 'again', 'no', 'when', 'same', 'how', 'other', 'which', 'you', 'after', 'most', 'such', 'why', 'a', 'off', 'i', 'yours', 'so', 'the', 'having', 'once']`